### PR TITLE
[hotfix] add erc4626 and native wrap as united wrap swap option

### DIFF
--- a/contracts/1delta/composer/enums/MiscEnums.sol
+++ b/contracts/1delta/composer/enums/MiscEnums.sol
@@ -18,3 +18,9 @@ enum DodoSelector {
     SELL_BASE,
     SELL_QUOTE
 }
+
+enum WrapOperation {
+    NATIVE,
+    ERC4626_DEPOSIT,
+    ERC4626_REDEEM
+}

--- a/contracts/1delta/composer/generic/bridges/Across/Across.sol
+++ b/contracts/1delta/composer/generic/bridges/Across/Across.sol
@@ -1,9 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.28;
 
-import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import {BaseUtils} from "contracts/1delta/composer/generic/BaseUtils.sol";
-import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 contract Across is BaseUtils {
     /**

--- a/contracts/1delta/composer/quoter/QuoterLight.sol
+++ b/contracts/1delta/composer/quoter/QuoterLight.sol
@@ -15,8 +15,12 @@ import {LBQuoter} from "./dex/LBQuoter.sol";
 import {KTXQuoter} from "./dex/KTXQuoter.sol";
 import {GMXQuoter} from "./dex/GMXV1Quoter.sol";
 import {BalancerV2Quoter} from "./dex/BalancerV2Quoter.sol";
+import {WrapperQuoter} from "./dex/WrapperQuoter.sol";
+
+// solhint-disable max-line-length
 
 contract QuoterLight is
+    WrapperQuoter,
     BalancerV3Quoter,
     V4TypeQuoter,
     V3TypeQuoter,
@@ -175,10 +179,9 @@ contract QuoterLight is
         }
         // sync swap style
         else if (dexTypeId == DexTypeMappings.SYNC_SWAP_ID) {
-            return _getSyncSwapAmoutnOut(tokenIn, amountIn, currentOffset);
-        } else if (dexTypeId == DexTypeMappings.NATIVE_WRAP_ID) {
-            // wrapping has no effect
-            return (amountIn, currentOffset + 21);
+            return _quoteSyncSwapExactIn(tokenIn, amountIn, currentOffset);
+        } else if (dexTypeId == DexTypeMappings.ASSET_WRAP_ID) {
+            return _quoteWrapperExactIn(tokenIn, tokenOut, amountIn, currentOffset);
         } else {
             revert InvalidDexId();
         }

--- a/contracts/1delta/composer/quoter/dex/SyncQuoter.sol
+++ b/contracts/1delta/composer/quoter/dex/SyncQuoter.sol
@@ -2,8 +2,10 @@
 
 pragma solidity ^0.8.28;
 
+// solhint-disable max-line-length
+
 abstract contract SyncQuoter {
-    function _getSyncSwapAmoutnOut(address tokenIn, uint256 amountIn, uint256 currentOffset) internal view returns (uint256 amountOut, uint256) {
+    function _quoteSyncSwapExactIn(address tokenIn, uint256 amountIn, uint256 currentOffset) internal view returns (uint256 amountOut, uint256) {
         assembly {
             let syncSwapData := calldataload(currentOffset)
             let pool := shr(96, syncSwapData)

--- a/contracts/1delta/composer/quoter/dex/WrapperQuoter.sol
+++ b/contracts/1delta/composer/quoter/dex/WrapperQuoter.sol
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+pragma solidity 0.8.28;
+
+// solhint-disable max-line-length
+
+/**
+ * @title Quoter for wrapper
+ */
+abstract contract WrapperQuoter {
+    /// @dev  previewDeposit(...)
+    bytes32 private constant ERC4626_PREVIEW_DEPOSIT = 0xef8b30f700000000000000000000000000000000000000000000000000000000;
+
+    /// @dev  previewRedeem(...)
+    bytes32 private constant ERC4626_PREVIEW_REDEEM = 0x4cdad50600000000000000000000000000000000000000000000000000000000;
+
+    /**
+     * This one is for overring the DEX implementation
+     * | Offset | Length (bytes) | Description         |
+     * |--------|----------------|---------------------|
+     * | 0      | 1              | operation           |
+     * | 1      | 1              | pay config          | <- 0: caller pays; 1: contract pays; greater: pre-funded
+     */
+    function _quoteWrapperExactIn(
+        address assetIn,
+        address assetOut,
+        uint256 amount,
+        uint256 currentOffset
+    )
+        internal
+        virtual
+        returns (uint256 amountOut, uint256 operationThenOffset)
+    {
+        assembly {
+            operationThenOffset := calldataload(currentOffset)
+            // shift operation to lowest byte
+            switch shr(248, operationThenOffset)
+            case 0 { amountOut := amount }
+            // the other 2 cases are the vaults
+            case 1 {
+                mstore(0, ERC4626_PREVIEW_DEPOSIT)
+                mstore(0x4, amount) // assets
+                if iszero(call(gas(), assetOut, 0x0, 0, 0x24, 0x0, 0x20)) {
+                    returndatacopy(0, 0, returndatasize())
+                    revert(0x0, returndatasize())
+                }
+                amountOut := mload(0)
+            }
+            default {
+                // this one should not need an approve
+                mstore(0, ERC4626_PREVIEW_REDEEM)
+                mstore(0x4, amount) // shares
+                if iszero(call(gas(), assetIn, 0x0, 0, 0x24, 0x0, 0x20)) {
+                    returndatacopy(0, 0, returndatasize())
+                    revert(0x0, returndatasize())
+                }
+                amountOut := mload(0)
+            }
+            operationThenOffset := add(currentOffset, 2)
+        }
+        return (amountOut, operationThenOffset);
+    }
+}

--- a/contracts/1delta/composer/swappers/BaseSwapper.sol
+++ b/contracts/1delta/composer/swappers/BaseSwapper.sol
@@ -10,7 +10,7 @@ import {V2TypeGeneric} from "./dex/V2Type.sol";
 import {WooFiSwapper} from "./dex/WooFi.sol";
 import {DodoV2Swapper} from "./dex/DodoV2Swapper.sol";
 import {LBSwapper} from "./dex/LBSwapper.sol";
-import {NativeWrapper} from "./dex/NativeWrapper.sol";
+import {Wrapper} from "./dex/Wrapper.sol";
 import {GMXSwapper} from "./dex/GMXSwapper.sol";
 import {SyncSwapper} from "./dex/SyncSwapper.sol";
 import {CurveSwapper} from "./dex/CurveSwapper.sol";
@@ -68,7 +68,7 @@ import {BalancerV3Swapper} from "./dex/BalancerV3Swapper.sol";
  *             Solidly:121 - 130
  */
 abstract contract BaseSwapper is
-    NativeWrapper,
+    Wrapper,
     V4TypeGeneric,
     V3TypeGeneric,
     V2TypeGeneric,
@@ -372,8 +372,8 @@ abstract contract BaseSwapper is
             }
         }
         // Rest: Rare wrap/unwrap operations
-        else if (dexTypeId == DexTypeMappings.NATIVE_WRAP_ID) {
-            return _wrapOrUnwrapSimple(amountIn, currentOffset);
+        else if (dexTypeId == DexTypeMappings.ASSET_WRAP_ID) {
+            return _wrapperOperation(tokenIn, tokenOut, amountIn, receiver, payer, currentOffset);
         }
 
         // If no match was found, revert

--- a/contracts/1delta/composer/swappers/dex/DexTypeMappings.sol
+++ b/contracts/1delta/composer/swappers/dex/DexTypeMappings.sol
@@ -48,5 +48,5 @@ library DexTypeMappings {
      */
     // wrappers
     uint256 internal constant ERC4626_ID = 253;
-    uint256 internal constant NATIVE_WRAP_ID = 254;
+    uint256 internal constant ASSET_WRAP_ID = 254;
 }

--- a/contracts/1delta/composer/swappers/dex/Wrapper.sol
+++ b/contracts/1delta/composer/swappers/dex/Wrapper.sol
@@ -1,0 +1,221 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+pragma solidity 0.8.28;
+
+// solhint-disable max-line-length
+
+import {ERC20Selectors} from "../../../shared/selectors/ERC20Selectors.sol";
+import {Masks} from "../../../shared/masks/Masks.sol";
+
+/**
+ * @title ERC4626 vault & native wrap "swapper" contract
+ * The logic is as follows
+ * - the only parameter is an indicator for the operation (0: native wrap | 1: deposit | 2: redeem)
+ * - the native case has the direction implied by the asset address (asset=0 mean native),
+ *   as such, assetIn=0 means wrap, in this case amountIn=amountOut
+ * - ERC4626 only uses deposit and redeem (as these are the exact in operations), these
+ *   require the output amount to be read from the returndata
+ */
+abstract contract Wrapper is ERC20Selectors, Masks {
+    /// @dev  deposit(...)
+    bytes32 private constant ERC4626_DEPOSIT = 0x6e553f6500000000000000000000000000000000000000000000000000000000;
+
+    /// @dev  redeem(...)
+    bytes32 private constant ERC4626_REDEEM = 0xba08765200000000000000000000000000000000000000000000000000000000;
+
+    // NativeTransferFailed()
+    bytes4 private constant NATIVE_TRANSFER = 0xf4b3b1bc;
+
+    // WrapFailed()
+    bytes4 private constant WRAP = 0xc30d93ce;
+
+    // Note that the for native wrapping, the assetIn/assetOut constellation defines the direction
+    // For ERC4626, the direction is defined by the operation parameter
+    // 1: deposit: deposit to vault, assetIn is the underlying and assetOut is the vault
+    // 2: redeem: redeem shares, assetIn is the vault, assetOut is the underlyinh
+    /**
+     * This one is for overring the DEX implementation
+     * | Offset | Length (bytes) | Description         |
+     * |--------|----------------|---------------------|
+     * | 0      | 1              | operation           |
+     * | 1      | 1              | pay config          | <- 0: caller pays; 1: contract pays; greater: pre-funded
+     */
+    function _wrapperOperation(
+        address assetIn,
+        address assetOut,
+        uint256 amount,
+        address receiver,
+        address callerAddress,
+        uint256 currentOffset
+    )
+        internal
+        virtual
+        returns (uint256 amountOut, uint256 operationThenOffset)
+    {
+        assembly {
+            operationThenOffset := calldataload(currentOffset)
+            let ptr := mload(0x40)
+            // only need to check whether we have to pull from caller
+            // Note: this should be avoided for native in
+            if iszero(and(shr(240, operationThenOffset), UINT8_MASK)) {
+                // selector for transferFrom(address,address,uint256)
+                mstore(ptr, ERC20_TRANSFER_FROM)
+                mstore(add(ptr, 0x04), callerAddress)
+                mstore(add(ptr, 0x24), address())
+                mstore(add(ptr, 0x44), amount)
+
+                let success := call(gas(), assetIn, 0, ptr, 0x64, 0, 32)
+
+                let rdsize := returndatasize()
+
+                if iszero(
+                    and(
+                        success, // call itself succeeded
+                        or(
+                            iszero(rdsize), // no return data, or
+                            and(
+                                gt(rdsize, 31), // at least 32 bytes
+                                eq(mload(0), 1) // starts with uint256(1)
+                            )
+                        )
+                    )
+                ) {
+                    returndatacopy(0, 0, rdsize)
+                    revert(0, rdsize)
+                }
+            }
+
+            // shift operation to lowest byte
+            switch shr(248, operationThenOffset)
+            case 0 {
+                amountOut := amount
+                // native is input: wrap
+                switch iszero(assetIn)
+                case 1 {
+                    if iszero(
+                        call(
+                            gas(),
+                            assetOut,
+                            amount, // ETH to deposit
+                            0x0, // no input
+                            0x0, // input size = zero
+                            0x0, // output = empty
+                            0x0 // output size = zero
+                        )
+                    ) {
+                        // revert when native transfer fails
+                        mstore(0, NATIVE_TRANSFER)
+                        revert(0, 0x4)
+                    }
+                    // transfer to destination if needed
+                    // this is to make receipts of native consistent with pre-funded
+                    // calls
+                    if xor(receiver, address()) {
+                        // selector for transfer(address,uint256)
+                        mstore(ptr, ERC20_TRANSFER)
+                        mstore(add(ptr, 0x04), receiver)
+                        mstore(add(ptr, 0x24), amount)
+                        let success := call(gas(), assetOut, 0, ptr, 0x44, 0, 32)
+
+                        let rdsize := returndatasize()
+
+                        // Check for ERC20 success. ERC20 tokens should return a boolean,
+                        // but some don't. We accept 0-length return data as success, or at
+                        // least 32 bytes that starts with a 32-byte boolean true.
+                        success :=
+                            and(
+                                success, // call itself succeeded
+                                or(
+                                    iszero(rdsize), // no return data, or
+                                    and(
+                                        gt(rdsize, 31), // at least 32 bytes
+                                        eq(mload(0), 1) // starts with uint256(1)
+                                    )
+                                )
+                            )
+
+                        if iszero(success) {
+                            returndatacopy(0, 0, rdsize)
+                            revert(0, rdsize)
+                        }
+                    }
+                }
+                // assetIn is expected to be wNative
+                // note that we do not do a transfer to a receiver as DEXs that require native require
+                // to attach native to the respective swap call
+                default {
+                    // selector for withdraw(uint256)
+                    mstore(0x0, 0x2e1a7d4d00000000000000000000000000000000000000000000000000000000)
+                    mstore(0x4, amount)
+                    if iszero(
+                        call(
+                            gas(),
+                            assetIn,
+                            0x0, // no ETH
+                            0x0, // start of data
+                            0x24, // input size = selector plus amount
+                            0x0, // output = empty
+                            0x0 // output size = zero
+                        )
+                    ) {
+                        // revert when native transfer fails
+                        mstore(0, WRAP)
+                        revert(0, 0x4)
+                    }
+
+                    // transfer native to receiver if needed
+                    if xor(receiver, address()) {
+                        if iszero(call(gas(), receiver, amount, 0x0, 0x0, 0x0, 0x0)) {
+                            // revert when native transfer fails
+                            mstore(0, NATIVE_TRANSFER)
+                            revert(0, 0x4)
+                        }
+                    }
+                }
+            }
+            // the other 2 cases have receiver as parameter
+            case 1 {
+                // Approve vault if needed
+                mstore(0x0, assetIn)
+                mstore(0x20, 0x1aae13105d9b6581c36534caba5708726e5ea1e03175e823c989a5756966d1f3) // CALL_MANAGEMENT_APPROVALS
+                mstore(0x20, keccak256(0x0, 0x40))
+                mstore(0x0, assetOut)
+                let key := keccak256(0x0, 0x40)
+                // check if already approved
+                if iszero(sload(key)) {
+                    // selector for approve(address,uint256)
+                    mstore(ptr, ERC20_APPROVE)
+                    mstore(add(ptr, 0x04), assetOut)
+                    mstore(add(ptr, 0x24), MAX_UINT256)
+                    pop(call(gas(), assetIn, 0, ptr, 0x44, ptr, 32))
+                    sstore(key, 1)
+                }
+
+                mstore(ptr, ERC4626_DEPOSIT)
+                mstore(add(ptr, 0x4), amount) // assets
+                mstore(add(ptr, 0x24), receiver) // receiver
+
+                if iszero(call(gas(), assetOut, 0x0, ptr, 0x44, 0x0, 0x20)) {
+                    returndatacopy(0, 0, returndatasize())
+                    revert(0x0, returndatasize())
+                }
+                amountOut := mload(0)
+            }
+            default {
+                // this one should not need an approve
+                mstore(ptr, ERC4626_REDEEM)
+                mstore(add(ptr, 0x4), amount) // shares
+                mstore(add(ptr, 0x24), receiver) // receiver
+                mstore(add(ptr, 0x44), address()) // owner is self as we expect to hold the vault shares
+
+                if iszero(call(gas(), assetIn, 0x0, ptr, 0x64, 0x0, 0x20)) {
+                    returndatacopy(0, 0, returndatasize())
+                    revert(0x0, returndatasize())
+                }
+                amountOut := mload(0)
+            }
+            operationThenOffset := add(currentOffset, 2)
+        }
+        return (amountOut, operationThenOffset);
+    }
+}

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -483,17 +483,6 @@ const config: HardhatUserConfig = {
       }
     ],
     overrides: {
-      // proxy
-      "contracts/1delta/proxy/DeltaBrokerGen2.sol": {
-        version: '0.8.28',
-        settings: {
-          optimizer: {
-            enabled: true,
-            runs: 1_000_000,
-          },
-          evmVersion: 'cancun',
-        },
-      },
       // deploy factory
       "contracts/1delta/contracts/1delta/shared/DeployFactory.sol": {
         version: '0.8.28',
@@ -516,8 +505,40 @@ const config: HardhatUserConfig = {
           evmVersion: 'paris',
         },
       },
+      // forwarder
+      "contracts/1delta/composer/generic/CallForwarder.sol": {
+        version: '0.8.28',
+        settings: {
+          optimizer: {
+            enabled: true,
+            runs: 1_000_000,
+          },
+          evmVersion: 'paris',
+        },
+      },// proxy
+      "contracts/external-protocols/openzeppelin/proxy/transparent/TransparentUpgradeableProxy.sol": {
+        version: '0.8.28',
+        settings: {
+          optimizer: {
+            enabled: true,
+            runs: 1_000_000,
+          },
+          evmVersion: 'paris',
+        },
+      },
       // composers
       "contracts/1delta/composer/chains/arbitrum-one/Composer.sol": {
+        version: '0.8.28',
+        settings: {
+          optimizer: {
+            enabled: true,
+            runs: 2_500,
+          },
+          evmVersion: 'cancun',
+        },
+      },
+      // composers
+      "contracts/1delta/composer/chains/optimism/Composer.sol": {
         version: '0.8.28',
         settings: {
           optimizer: {

--- a/scripts/_shared/addresses.ts
+++ b/scripts/_shared/addresses.ts
@@ -1,7 +1,11 @@
+import { Chain } from "@1delta/asset-registry"
+
 export const DEPLOY_FACTORY = "0x16c4Dc0f662E2bEceC91fC5E7aeeC6a25684698A"
+export const FORWARDER = "0xfca1137E7b0aE4CbaAd630CcC1C1B24F30c19A30"
+
 
 export const COMPOSER_LOGICS = {
-
+    [Chain.ARBITRUM_ONE]: "0xD48FeCce2cE91e1c644B8C59516567f2041CE260"
 }
 
 export const COMPOSER_PROXIES = {

--- a/scripts/_shared/composers/arbitrum-one.ts
+++ b/scripts/_shared/composers/arbitrum-one.ts
@@ -1,0 +1,23 @@
+
+import { ethers } from "hardhat";
+import { OneDeltaComposerArbitrumOne__factory } from "../../../types";
+import { Chain } from "@1delta/asset-registry";
+
+async function main() {
+    const accounts = await ethers.getSigners()
+    const operator = accounts[1]
+    const chainId = await operator.getChainId();
+    if (String(chainId) !== Chain.ARBITRUM_ONE) throw new Error("IC")
+    console.log("operator", operator.address, "on", chainId)
+    const composer = await new OneDeltaComposerArbitrumOne__factory(operator).deploy()
+    await composer.deployed()
+
+    console.log("deployed expected to", composer.address)
+}
+
+main()
+    .then(() => process.exit(0))
+    .catch((error) => {
+        console.error(error);
+        process.exit(1);
+    });

--- a/scripts/_shared/deployForwarder.ts
+++ b/scripts/_shared/deployForwarder.ts
@@ -1,0 +1,50 @@
+
+import { ethers } from "hardhat";
+import { CallForwarder__factory, DeployFactory__factory } from "../../types";
+import { DEPLOY_FACTORY } from "./addresses";
+import { keccak256 } from "ethers/lib/utils";
+
+/**
+export FACTORY="0x16c4Dc0f662E2bEceC91fC5E7aeeC6a25684698A"
+export CALLER="0x16c4Dc0f662E2bEceC91fC5E7aeeC6a25684698A"
+export INIT_CODE_HASH="0x8757633895e8e012e215fd6d3723aa06ab9c7d233659a957ee8a83e05c39acc3"
+export GPU_DEVICE=255
+export ADDRESS_START_WITH="fca11"
+export ADDRESS_END_WITH="0"
+cargo run --release $FACTORY $CALLER $INIT_CODE_HASH $GPU_DEVICE $ADDRESS_START_WITH $ADDRESS_END_WITH
+ */
+
+// 0x16c4dc0f662e2becec91fc5e7aeec6a25684698a849b92e0cb5b7703780b288c => 0xfca1137E7b0aE4CbaAd630CcC1C1B24F30c19A30
+
+async function main() {
+    const accounts = await ethers.getSigners()
+    const operator = accounts[1]
+    const chainId = await operator.getChainId();
+    console.log("operator", operator.address, "on", chainId)
+
+    console.log("Get deploy factory")
+
+    const salt = "0x16c4dc0f662e2becec91fc5e7aeec6a25684698a849b92e0cb5b7703780b288c"
+    //  deploys to 0xfca1137E7b0aE4CbaAd630CcC1C1B24F30c19A30
+    const bytecode = CallForwarder__factory.bytecode
+
+    const initCode = keccak256(bytecode)
+    console.log("initCode", initCode) // 0x8757633895e8e012e215fd6d3723aa06ab9c7d233659a957ee8a83e05c39acc3 (paris, 1m steps)
+
+    const deployFactory = await new DeployFactory__factory(operator).attach(DEPLOY_FACTORY)
+    const address = await deployFactory.computeAddress(salt, initCode)
+    console.log("address", address)
+    const estimate = await deployFactory.estimateGas.deploy(salt, bytecode)
+    console.log("estimate", estimate)
+    const tx = await deployFactory.deploy(salt, bytecode, { gasLimit: estimate.add(100) })
+    await tx.wait()
+
+    console.log("deployed expected to", address)
+}
+
+main()
+    .then(() => process.exit(0))
+    .catch((error) => {
+        console.error(error);
+        process.exit(1);
+    });

--- a/scripts/verify_fw.js
+++ b/scripts/verify_fw.js
@@ -1,0 +1,2 @@
+
+// npx hardhat verify --network arbitrum 0xfca1137E7b0aE4CbaAd630CcC1C1B24F30c19A30 --contract contracts/1delta/composer/generic/CallForwarder.sol:CallForwarder 

--- a/test/composer/dex/MoeV1.sol
+++ b/test/composer/dex/MoeV1.sol
@@ -8,6 +8,8 @@ import {Chains, Tokens, Lenders} from "../../data/LenderRegistry.sol";
 import "../utils/CalldataLib.sol";
 import {ComposerPlugin, IComposerLike} from "plugins/ComposerPlugin.sol";
 
+// solhint-disable max-line-length
+
 interface IF {
     function getPool(address tokenA, address tokenB, uint24 fee) external view returns (address);
     function getPool(address tokenA, address tokenB, int24 fee) external view returns (address);

--- a/test/composer/dex/SyncSwap.sol
+++ b/test/composer/dex/SyncSwap.sol
@@ -2,7 +2,6 @@
 pragma solidity ^0.8.19;
 
 import {console} from "forge-std/console.sol";
-
 import "../../../contracts/1delta/composer//quoter/QuoterLight.sol";
 import {IERC20All} from "../../shared/interfaces/IERC20All.sol";
 import {BaseTest} from "../../shared/BaseTest.sol";

--- a/test/composer/utils/CalldataLib.sol
+++ b/test/composer/utils/CalldataLib.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.19;
 import "contracts/1delta/composer/enums/DeltaEnums.sol";
 import "contracts/1delta/composer/swappers/dex/DexTypeMappings.sol";
 import "contracts/1delta/composer/swappers/callbacks/DexForkMappings.sol";
-import {DexPayConfig, SweepType, DodoSelector} from "contracts/1delta/composer/enums/MiscEnums.sol";
+import {DexPayConfig, SweepType, DodoSelector, WrapOperation} from "contracts/1delta/composer/enums/MiscEnums.sol";
 
 // solhint-disable max-line-length
 
@@ -693,6 +693,28 @@ library CalldataLib {
             uint8(selectorId), // fee tier to validate pool
             uint16(uint256(cfg)) //
         );
+    }
+
+    // wapper operation for swaps
+    function encodeWrapperSwap(
+        bytes memory currentData,
+        address assetOut,
+        address receiver,
+        WrapOperation operation,
+        DexPayConfig cfg
+    )
+        internal
+        pure
+        returns (bytes memory)
+    {
+        return abi.encodePacked(
+            currentData,
+            assetOut,
+            receiver,
+            uint8(DexTypeMappings.ASSET_WRAP_ID),
+            uint8(uint256(operation)),
+            uint8(uint256(cfg)) //
+        ); // 14 bytes
     }
 
     function encodeNextGenDexSettle(address singleton, uint256 nativeAmount) internal pure returns (bytes memory) {


### PR DESCRIPTION
- can now use ERC4626 under swap operations next to native wrap/unwrap
- added to quoter
- tests added under `test_light_wrap_...`