### PR TITLE
DTA-2199: Add a simple test for quoter path testing

### DIFF
--- a/test/calldata-tester/CalldataTest.t.sol
+++ b/test/calldata-tester/CalldataTest.t.sol
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import "../data/LenderRegistry.sol";
+import {BaseTest} from "test/shared/BaseTest.sol";
+import {QuoterLight} from "contracts/1delta/composer/quoter/QuoterLight.sol";
+import {console} from "forge-std/console.sol";
+
+contract CalldataTest is BaseTest {
+    QuoterLight public quoter;
+    bytes internal inputCalldata;
+
+    /// @dev Add the test calldata to the testCalldata or pass it as an env variable with the var name of CD
+    bytes internal testCalldata =
+        hex"00002f2a2543b76a4166549f7aab2e75bef0aefc5b0f1111111111111111111111111111111111111111002f5e87c9312fa29aed5c179e456625d79015299c0001f40000";
+    address internal inputToken = 0x82aF49447D8a07e3bd95BD0d56f35241523fBab1;
+    uint256 internal amount = 1000000000000000000;
+    // --------------------------------------------------------------- //
+
+    function setUp() public {
+        _init(Chains.ARBITRUM_ONE, 0, true);
+        quoter = new QuoterLight();
+        // get the calldata from cli
+        inputCalldata = vm.envOr("CD", bytes(testCalldata));
+    }
+
+    /// @dev assumes that the input bytes can directly be called on the quoter (with function selector and the amountIn)
+    function test_calldata_1() public {
+        address(quoter).call(inputCalldata);
+    }
+
+    /// @dev assumes that the input bytes is the swaps path calldata, this requires inputToken and amount to be set
+    function test_calldata_2() public {
+        quoter.quote(amount, abi.encodePacked(inputToken, inputCalldata));
+    }
+}


### PR DESCRIPTION
# Adds a simple test to test the swap path on Quoter contract
it has 2 tests:
- `test_calldata_1` : assumes the input bytes can be directly called on the quoter
- `test_calldata_2` : requires `amount`,  `inputToken` and the calldata, then calls the quoter with these input data
The input bytes can be passed as an env var or added directly to the test 

### Execute the test with env var
```bash
clear && CD=0x123456 forge test --match-test=test_calldata -vvvv
```
### Execute the test by directly adding the required vars to the test
Modify the test contract (the swap-sdk test generates these, they can be simply be copy-pasted here)
```solidity
    /// @dev Add the test calldata to the testCalldata or pass it as an env variable with the var name of CD
    bytes internal testCalldata =
        hex"00002f2a2543b76a4166549f7aab2e75bef0aefc5b0f1111111111111111111111111111111111111111002f5e87c9312fa29aed5c179e456625d79015299c0001f40000";
    address internal inputToken = 0x82aF49447D8a07e3bd95BD0d56f35241523fBab1;
    uint256 internal amount = 1000000000000000000;
    // --------------------------------------------------------------- //
```
```bash
clear &&  forge test --match-test=test_calldata -vvvv
```


